### PR TITLE
Add more libgodot C interfaces to simplify the use of libdot.

### DIFF
--- a/core/extension/godot_instance.cpp
+++ b/core/extension/godot_instance.cpp
@@ -46,6 +46,9 @@ GodotInstance::~GodotInstance() {
 }
 
 bool GodotInstance::initialize(GDExtensionInitializationFunction p_init_func) {
+	if(p_init_func == nullptr) {
+		return true;
+	}
 	GDExtensionManager *gdextension_manager = GDExtensionManager::get_singleton();
 	GDExtensionConstPtr<const GDExtensionInitializationFunction> ptr((const GDExtensionInitializationFunction *)&p_init_func);
 	GDExtensionManager::LoadStatus status = gdextension_manager->load_function_extension("libgodot://main", ptr);

--- a/core/extension/libgodot.h
+++ b/core/extension/libgodot.h
@@ -49,7 +49,7 @@ extern "C" {
  *
  * @return A pointer to created \ref GodotInstance GDExtension object or nullptr if there was an error.
  */
-GDExtensionObjectPtr libgodot_create_godot_instance(int p_argc, char *p_argv[], GDExtensionInitializationFunction p_init_func);
+__declspec(dllexport) GDExtensionObjectPtr libgodot_create_godot_instance(int p_argc, char *p_argv[], GDExtensionInitializationFunction p_init_func, void *p_platform_data);
 
 /**
  * @name libgodot_destroy_godot_instance
@@ -60,7 +60,7 @@ GDExtensionObjectPtr libgodot_create_godot_instance(int p_argc, char *p_argv[], 
  * @param p_godot_instance The reference to the GodotInstance object to destroy.
  *
  */
-void libgodot_destroy_godot_instance(GDExtensionObjectPtr p_godot_instance);
+__declspec(dllexport) void libgodot_destroy_godot_instance(GDExtensionObjectPtr p_godot_instance);
 
 #ifdef __cplusplus
 }

--- a/core/extension/libgodot.h
+++ b/core/extension/libgodot.h
@@ -27,9 +27,18 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
-
 #ifndef LIBGODOT_H
 #define LIBGODOT_H
+#ifdef _WIN32
+    #define EXPORT_SYMBOL __declspec(dllexport)
+#elif defined(__GNUC__)
+    #define EXPORT_SYMBOL __attribute__((visibility("default")))
+#else
+    #define EXPORT_SYMBOL
+#endif
+
+
+
 
 #ifdef __cplusplus
 extern "C" {
@@ -49,7 +58,7 @@ extern "C" {
  *
  * @return A pointer to created \ref GodotInstance GDExtension object or nullptr if there was an error.
  */
-__declspec(dllexport) GDExtensionObjectPtr libgodot_create_godot_instance(int p_argc, char *p_argv[], GDExtensionInitializationFunction p_init_func, void *p_platform_data);
+EXPORT_SYMBOL GDExtensionObjectPtr libgodot_create_godot_instance(int p_argc, char *p_argv[], GDExtensionInitializationFunction p_init_func, void *p_platform_data);
 
 /**
  * @name libgodot_destroy_godot_instance
@@ -60,7 +69,30 @@ __declspec(dllexport) GDExtensionObjectPtr libgodot_create_godot_instance(int p_
  * @param p_godot_instance The reference to the GodotInstance object to destroy.
  *
  */
-__declspec(dllexport) void libgodot_destroy_godot_instance(GDExtensionObjectPtr p_godot_instance);
+EXPORT_SYMBOL void libgodot_destroy_godot_instance(GDExtensionObjectPtr p_godot_instance);
+
+
+/**
+ * @name libgodot_start_godot_instance
+ * @since 4.4
+ *
+ * Godot instance start.
+ *
+ * @param p_godot_instance The reference to the GodotInstance object to destroy.
+ *
+ */
+EXPORT_SYMBOL bool libgodot_start_godot_instance(GDExtensionObjectPtr p_godot_instance);
+/**
+ * @name libgodot_iteration_godot_instance
+ * @since 4.4
+ *
+ * Godot instance iteration.
+ *
+ * @param p_godot_instance The reference to the GodotInstance object to destroy.
+ *
+ */
+EXPORT_SYMBOL bool libgodot_iteration_godot_instance(GDExtensionObjectPtr p_godot_instance);
+
 
 #ifdef __cplusplus
 }

--- a/platform/ios/libgodot_ios.mm
+++ b/platform/ios/libgodot_ios.mm
@@ -38,7 +38,7 @@ static OS_IOS *os = nullptr;
 
 static GodotInstance *instance = nullptr;
 
-GDExtensionObjectPtr libgodot_create_godot_instance(int p_argc, char *p_argv[], GDExtensionInitializationFunction p_init_func) {
+GDExtensionObjectPtr libgodot_create_godot_instance(int p_argc, char *p_argv[], GDExtensionInitializationFunction p_init_func, void *p_platform_data) {
 	ERR_FAIL_COND_V_MSG(instance != nullptr, nullptr, "Only one Godot Instance may be created.");
 
 	os = new OS_IOS();

--- a/platform/ios/libgodot_ios.mm
+++ b/platform/ios/libgodot_ios.mm
@@ -67,3 +67,23 @@ void libgodot_destroy_godot_instance(GDExtensionObjectPtr p_godot_instance) {
 		Main::cleanup();
 	}
 }
+
+
+bool libgodot_start_godot_instance(GDExtensionObjectPtr p_godot_instance) {
+	bool ret = false;
+	GodotInstance *godot_instance = (GodotInstance *)p_godot_instance;
+	if (instance == godot_instance) {
+		ret = godot_instance->start();
+	}
+	return ret;
+}
+
+
+bool libgodot_iteration_godot_instance(GDExtensionObjectPtr p_godot_instance) {
+	bool ret = false;
+	GodotInstance *godot_instance = (GodotInstance *)p_godot_instance;
+	if (instance == godot_instance) {
+		ret = godot_instance->iteration();
+	}
+	return ret;
+}

--- a/platform/linuxbsd/libgodot_linuxbsd.cpp
+++ b/platform/linuxbsd/libgodot_linuxbsd.cpp
@@ -39,7 +39,7 @@ static OS_LinuxBSD *os = nullptr;
 
 static GodotInstance *instance = nullptr;
 
-GDExtensionObjectPtr libgodot_create_godot_instance(int p_argc, char *p_argv[], GDExtensionInitializationFunction p_init_func) {
+GDExtensionObjectPtr libgodot_create_godot_instance(int p_argc, char *p_argv[], GDExtensionInitializationFunction p_init_func, void *p_platform_data) {
 	ERR_FAIL_COND_V_MSG(instance != nullptr, nullptr, "Only one Godot Instance may be created.");
 
 	os = new OS_LinuxBSD();

--- a/platform/linuxbsd/libgodot_linuxbsd.cpp
+++ b/platform/linuxbsd/libgodot_linuxbsd.cpp
@@ -68,3 +68,21 @@ void libgodot_destroy_godot_instance(GDExtensionObjectPtr p_godot_instance) {
 		Main::cleanup();
 	}
 }
+bool libgodot_start_godot_instance(GDExtensionObjectPtr p_godot_instance) {
+	bool ret = false;
+	GodotInstance *godot_instance = (GodotInstance *)p_godot_instance;
+	if (instance == godot_instance) {
+		ret = godot_instance->start();
+	}
+	return ret;
+}
+
+
+bool libgodot_iteration_godot_instance(GDExtensionObjectPtr p_godot_instance) {
+	bool ret = false;
+	GodotInstance *godot_instance = (GodotInstance *)p_godot_instance;
+	if (instance == godot_instance) {
+		ret = godot_instance->iteration();
+	}
+	return ret;
+}

--- a/platform/macos/libgodot_macos.mm
+++ b/platform/macos/libgodot_macos.mm
@@ -39,7 +39,7 @@ static OS_MacOS *os = nullptr;
 
 static GodotInstance *instance = nullptr;
 
-GDExtensionObjectPtr libgodot_create_godot_instance(int p_argc, char *p_argv[], GDExtensionInitializationFunction p_init_func) {
+GDExtensionObjectPtr libgodot_create_godot_instance(int p_argc, char *p_argv[], GDExtensionInitializationFunction p_init_func, void *p_platform_data) {
 	ERR_FAIL_COND_V_MSG(instance != nullptr, nullptr, "Only one Godot Instance may be created.");
 
 	os = new OS_MacOS();

--- a/platform/macos/libgodot_macos.mm
+++ b/platform/macos/libgodot_macos.mm
@@ -70,3 +70,22 @@ void libgodot_destroy_godot_instance(GDExtensionObjectPtr p_godot_instance) {
 		Main::cleanup();
 	}
 }
+
+bool libgodot_start_godot_instance(GDExtensionObjectPtr p_godot_instance) {
+	bool ret = false;
+	GodotInstance *godot_instance = (GodotInstance *)p_godot_instance;
+	if (instance == godot_instance) {
+		ret = godot_instance->start();
+	}
+	return ret;
+}
+
+
+bool libgodot_iteration_godot_instance(GDExtensionObjectPtr p_godot_instance) {
+	bool ret = false;
+	GodotInstance *godot_instance = (GodotInstance *)p_godot_instance;
+	if (instance == godot_instance) {
+		ret = godot_instance->iteration();
+	}
+	return ret;
+}

--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -26,6 +26,10 @@ common_win = [
     "rendering_native_surface_windows.cpp",
 ]
 
+libgodot_files = [
+    "libgodot_windows.cpp",
+]
+
 if env.msvc:
     common_win += ["crash_handler_windows_seh.cpp"]
 else:
@@ -57,12 +61,12 @@ env.add_source_files(sources, common_win)
 sources += res_obj
 
 if env["library_type"] == "static_library":
-    prog = env.add_library("#bin/godot", sources, PROGSUFFIX=env["PROGSUFFIX"])
+    prog = env.add_library("#bin/godot", sources + libgodot_files)
     arrange_program_clean(prog)
 elif env["library_type"] == "shared_library":
-    prog = env.add_shared_library("#bin/godot", sources, PROGSUFFIX=env["PROGSUFFIX"])
+    prog = env.add_shared_library("#bin/godot", sources + libgodot_files)
     arrange_program_clean(prog)
-else:
+else: # building executable
     prog = env.add_program("#bin/godot", sources, PROGSUFFIX=env["PROGSUFFIX"])
     arrange_program_clean(prog)
 

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -5249,7 +5249,7 @@ DisplayServer::WindowID DisplayServerWindows::_create_window(WindowMode p_mode, 
 
 #ifdef RD_ENABLED
 		Ref<RenderingNativeSurfaceWindows> windows_surface = nullptr;
-#ifdef VULKAN_ENABLED || D3D12_ENABLED
+#if defined(VULKAN_ENABLED) || defined(D3D12_ENABLED)
 		if (rendering_driver == "vulkan" || rendering_driver == "d3d12") {
 			windows_surface = RenderingNativeSurfaceWindows::create(wd.hWnd, hInstance);
 		}
@@ -5283,7 +5283,6 @@ DisplayServer::WindowID DisplayServerWindows::_create_window(WindowMode p_mode, 
 			if (rendering_context->window_create(id, windows_surface) != OK) {
 				ERR_PRINT(vformat("Failed to create %s window.", rendering_driver));
 				memdelete(rendering_context);
-				memdelete(windows_surface);
 				rendering_context = nullptr;
 				windows.erase(id);
 				return INVALID_WINDOW_ID;
@@ -5292,7 +5291,6 @@ DisplayServer::WindowID DisplayServerWindows::_create_window(WindowMode p_mode, 
 			rendering_context->window_set_size(id, WindowRect.right - WindowRect.left, WindowRect.bottom - WindowRect.top);
 			rendering_context->window_set_vsync_mode(id, p_vsync_mode);
 			wd.context_created = true;
-			memdelete(windows_surface);
 		}
 #endif
 

--- a/platform/windows/libgodot_windows.cpp
+++ b/platform/windows/libgodot_windows.cpp
@@ -68,3 +68,23 @@ void libgodot_destroy_godot_instance(GDExtensionObjectPtr p_godot_instance) {
 		Main::cleanup();
 	}
 }
+
+bool libgodot_start_godot_instance(GDExtensionObjectPtr p_godot_instance) {
+	bool ret = false;
+	GodotInstance *godot_instance = (GodotInstance *)p_godot_instance;
+	if (instance == godot_instance) {
+		ret = godot_instance->start();
+	}
+	return ret;
+}
+
+
+bool libgodot_iteration_godot_instance(GDExtensionObjectPtr p_godot_instance) {
+	bool ret = false;
+	GodotInstance *godot_instance = (GodotInstance *)p_godot_instance;
+	if (instance == godot_instance) {
+		ret = godot_instance->iteration();
+	}
+	return ret;
+}
+

--- a/platform/windows/libgodot_windows.cpp
+++ b/platform/windows/libgodot_windows.cpp
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  libgodot_windows.cpp                                                 */
+/*  libgodot_windows.cpp                                                  */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -42,7 +42,7 @@ static GodotInstance *instance = nullptr;
 GDExtensionObjectPtr libgodot_create_godot_instance(int p_argc, char *p_argv[], GDExtensionInitializationFunction p_init_func, void *p_platform_data) {
 	ERR_FAIL_COND_V_MSG(instance != nullptr, nullptr, "Only one Godot Instance may be created.");
 
-	os = new OS_Windows((HINSTANCE) p_platform_data);
+	os = new OS_Windows((HINSTANCE)p_platform_data);
 
 	Error err = Main::setup(p_argv[0], p_argc - 1, &p_argv[1], false);
 	if (err != OK) {
@@ -78,7 +78,6 @@ bool libgodot_start_godot_instance(GDExtensionObjectPtr p_godot_instance) {
 	return ret;
 }
 
-
 bool libgodot_iteration_godot_instance(GDExtensionObjectPtr p_godot_instance) {
 	bool ret = false;
 	GodotInstance *godot_instance = (GodotInstance *)p_godot_instance;
@@ -87,4 +86,3 @@ bool libgodot_iteration_godot_instance(GDExtensionObjectPtr p_godot_instance) {
 	}
 	return ret;
 }
-

--- a/platform/windows/rendering_context_driver_vulkan_windows.cpp
+++ b/platform/windows/rendering_context_driver_vulkan_windows.cpp
@@ -32,6 +32,7 @@
 
 #include "core/os/os.h"
 
+#include "drivers/vulkan/rendering_native_surface_vulkan.h"
 #include "rendering_context_driver_vulkan_windows.h"
 
 #ifdef USE_VOLK
@@ -68,7 +69,7 @@ RenderingContextDriver::SurfaceID RenderingContextDriverVulkanWindows::surface_c
 	VkResult err = vkCreateWin32SurfaceKHR(instance_get(), &create_info, nullptr, &vk_surface);
 	ERR_FAIL_COND_V(err != VK_SUCCESS, SurfaceID());
 
-	Ref<RenderingNativeSurfaceVulkan> vulkan_surface = RenderingContextDriverVulkan::create(vk_surface);
+	Ref<RenderingNativeSurfaceVulkan> vulkan_surface = RenderingNativeSurfaceVulkan::create(vk_surface);
 	RenderingContextDriver::SurfaceID result = RenderingContextDriverVulkan::surface_create(vulkan_surface);
 	return result;
 }

--- a/platform/windows/rendering_context_driver_vulkan_windows.h
+++ b/platform/windows/rendering_context_driver_vulkan_windows.h
@@ -34,7 +34,7 @@
 #ifdef VULKAN_ENABLED
 
 #include "drivers/vulkan/rendering_context_driver_vulkan.h"
-#include "servers/rendering/rendering_native_surface.h"
+#include "platform/windows/rendering_native_surface_windows.h"
 
 class RenderingContextDriverVulkanWindows : public RenderingContextDriverVulkan {
 private:


### PR DESCRIPTION
merge libgodot window patch: https://github.com/migeran/libgodot_project/pull/6

Add more libgodot C interfaces to simplify the use of libdot.

libgodot.h :
EXPORT_SYMBOL bool libgodot_start_godot_instance(GDExtensionObjectPtr p_godot_instance);
EXPORT_SYMBOL bool libgodot_iteration_godot_instance(GDExtensionObjectPtr

demo: https://github.com/JiepengTan/libgodot_llgo_demo