### PR TITLE
Add more libgodot C interfaces to simplify the use of libgodot.

### DIFF
--- a/core/extension/godot_instance.cpp
+++ b/core/extension/godot_instance.cpp
@@ -46,6 +46,9 @@ GodotInstance::~GodotInstance() {
 }
 
 bool GodotInstance::initialize(GDExtensionInitializationFunction p_init_func) {
+	if (p_init_func == nullptr) {
+		return true;
+	}
 	GDExtensionManager *gdextension_manager = GDExtensionManager::get_singleton();
 	GDExtensionConstPtr<const GDExtensionInitializationFunction> ptr((const GDExtensionInitializationFunction *)&p_init_func);
 	GDExtensionManager::LoadStatus status = gdextension_manager->load_function_extension("libgodot://main", ptr);

--- a/core/extension/libgodot.h
+++ b/core/extension/libgodot.h
@@ -30,6 +30,13 @@
 
 #ifndef LIBGODOT_H
 #define LIBGODOT_H
+#ifdef _WIN32
+#define EXPORT_SYMBOL __declspec(dllexport)
+#elif defined(__GNUC__)
+#define EXPORT_SYMBOL __attribute__((visibility("default")))
+#else
+#define EXPORT_SYMBOL
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -49,7 +56,7 @@ extern "C" {
  *
  * @return A pointer to created \ref GodotInstance GDExtension object or nullptr if there was an error.
  */
-__declspec(dllexport) GDExtensionObjectPtr libgodot_create_godot_instance(int p_argc, char *p_argv[], GDExtensionInitializationFunction p_init_func, void *p_platform_data);
+EXPORT_SYMBOL GDExtensionObjectPtr libgodot_create_godot_instance(int p_argc, char *p_argv[], GDExtensionInitializationFunction p_init_func, void *p_platform_data);
 
 /**
  * @name libgodot_destroy_godot_instance
@@ -60,7 +67,28 @@ __declspec(dllexport) GDExtensionObjectPtr libgodot_create_godot_instance(int p_
  * @param p_godot_instance The reference to the GodotInstance object to destroy.
  *
  */
-__declspec(dllexport) void libgodot_destroy_godot_instance(GDExtensionObjectPtr p_godot_instance);
+EXPORT_SYMBOL void libgodot_destroy_godot_instance(GDExtensionObjectPtr p_godot_instance);
+
+/**
+ * @name libgodot_start_godot_instance
+ * @since 4.4
+ *
+ * Godot instance start.
+ *
+ * @param p_godot_instance The reference to the GodotInstance object to destroy.
+ *
+ */
+EXPORT_SYMBOL bool libgodot_start_godot_instance(GDExtensionObjectPtr p_godot_instance);
+/**
+ * @name libgodot_iteration_godot_instance
+ * @since 4.4
+ *
+ * Godot instance iteration.
+ *
+ * @param p_godot_instance The reference to the GodotInstance object to destroy.
+ *
+ */
+EXPORT_SYMBOL bool libgodot_iteration_godot_instance(GDExtensionObjectPtr p_godot_instance);
 
 #ifdef __cplusplus
 }

--- a/platform/ios/display_server_ios.mm
+++ b/platform/ios/display_server_ios.mm
@@ -81,7 +81,7 @@ DisplayServerIOS::DisplayServerIOS(const String &p_rendering_driver, WindowMode 
 		if (!layer) {
 			ERR_FAIL_MSG("Failed to create iOS Vulkan rendering layer.");
 		}
-		apple_surface = RenderingNativeSurfaceApple::create((CAMetalLayer *const *)&layer);
+		apple_surface = RenderingNativeSurfaceApple::create((__bridge void *)layer);
 		rendering_context = apple_surface->create_rendering_context();
 	}
 #endif

--- a/platform/ios/libgodot_ios.mm
+++ b/platform/ios/libgodot_ios.mm
@@ -67,3 +67,21 @@ void libgodot_destroy_godot_instance(GDExtensionObjectPtr p_godot_instance) {
 		Main::cleanup();
 	}
 }
+
+bool libgodot_start_godot_instance(GDExtensionObjectPtr p_godot_instance) {
+	bool ret = false;
+	GodotInstance *godot_instance = (GodotInstance *)p_godot_instance;
+	if (instance == godot_instance) {
+		ret = godot_instance->start();
+	}
+	return ret;
+}
+
+bool libgodot_iteration_godot_instance(GDExtensionObjectPtr p_godot_instance) {
+	bool ret = false;
+	GodotInstance *godot_instance = (GodotInstance *)p_godot_instance;
+	if (instance == godot_instance) {
+		ret = godot_instance->iteration();
+	}
+	return ret;
+}

--- a/platform/linuxbsd/libgodot_linuxbsd.cpp
+++ b/platform/linuxbsd/libgodot_linuxbsd.cpp
@@ -68,3 +68,20 @@ void libgodot_destroy_godot_instance(GDExtensionObjectPtr p_godot_instance) {
 		Main::cleanup();
 	}
 }
+bool libgodot_start_godot_instance(GDExtensionObjectPtr p_godot_instance) {
+	bool ret = false;
+	GodotInstance *godot_instance = (GodotInstance *)p_godot_instance;
+	if (instance == godot_instance) {
+		ret = godot_instance->start();
+	}
+	return ret;
+}
+
+bool libgodot_iteration_godot_instance(GDExtensionObjectPtr p_godot_instance) {
+	bool ret = false;
+	GodotInstance *godot_instance = (GodotInstance *)p_godot_instance;
+	if (instance == godot_instance) {
+		ret = godot_instance->iteration();
+	}
+	return ret;
+}

--- a/platform/macos/libgodot_macos.mm
+++ b/platform/macos/libgodot_macos.mm
@@ -70,3 +70,21 @@ void libgodot_destroy_godot_instance(GDExtensionObjectPtr p_godot_instance) {
 		Main::cleanup();
 	}
 }
+
+bool libgodot_start_godot_instance(GDExtensionObjectPtr p_godot_instance) {
+	bool ret = false;
+	GodotInstance *godot_instance = (GodotInstance *)p_godot_instance;
+	if (instance == godot_instance) {
+		ret = godot_instance->start();
+	}
+	return ret;
+}
+
+bool libgodot_iteration_godot_instance(GDExtensionObjectPtr p_godot_instance) {
+	bool ret = false;
+	GodotInstance *godot_instance = (GodotInstance *)p_godot_instance;
+	if (instance == godot_instance) {
+		ret = godot_instance->iteration();
+	}
+	return ret;
+}

--- a/platform/windows/libgodot_windows.cpp
+++ b/platform/windows/libgodot_windows.cpp
@@ -68,3 +68,21 @@ void libgodot_destroy_godot_instance(GDExtensionObjectPtr p_godot_instance) {
 		Main::cleanup();
 	}
 }
+
+bool libgodot_start_godot_instance(GDExtensionObjectPtr p_godot_instance) {
+	bool ret = false;
+	GodotInstance *godot_instance = (GodotInstance *)p_godot_instance;
+	if (instance == godot_instance) {
+		ret = godot_instance->start();
+	}
+	return ret;
+}
+
+bool libgodot_iteration_godot_instance(GDExtensionObjectPtr p_godot_instance) {
+	bool ret = false;
+	GodotInstance *godot_instance = (GodotInstance *)p_godot_instance;
+	if (instance == godot_instance) {
+		ret = godot_instance->iteration();
+	}
+	return ret;
+}


### PR DESCRIPTION
merge libgodot window patch: https://github.com/migeran/libgodot_project/pull/6

Add more libgodot C interfaces to simplify the use of libdot.

libgodot.h :
EXPORT_SYMBOL bool libgodot_start_godot_instance(GDExtensionObjectPtr p_godot_instance);
EXPORT_SYMBOL bool libgodot_iteration_godot_instance(GDExtensionObjectPtr

demo: https://github.com/JiepengTan/libgodot_llgo_demo